### PR TITLE
fix modal overflow along the y axis

### DIFF
--- a/simple-modal.css
+++ b/simple-modal.css
@@ -15,6 +15,7 @@
 	background-color: rgb(0, 0, 0, .5);
 	z-index: 9999;
 	text-align: center;
+	overflow-y: scroll;
 }
 
 .simple-modal.active


### PR DESCRIPTION
# issue:
Can't scroll modal in case it overflows along the y-axis.